### PR TITLE
Don't use relative import for qtfaststart

### DIFF
--- a/mvc/qtfaststart/processor.py
+++ b/mvc/qtfaststart/processor.py
@@ -9,7 +9,7 @@ import struct
 
 from StringIO import StringIO
 
-from qtfaststart.exceptions import FastStartException
+from mvc.qtfaststart.exceptions import FastStartException
 
 CHUNK_SIZE = 8192
 


### PR DESCRIPTION
Without this the windows build fails (even before the menu changes)
