### PR TITLE
bz19518: fix screenshot temp file handling on windows

### DIFF
--- a/mvc/conversion.py
+++ b/mvc/conversion.py
@@ -66,7 +66,7 @@ class Conversion(object):
     def run(self):
         logger.info('starting %r', self)
         try:
-            self.temp_fd, self.temp_output = tempfile.mkstemp(
+            self.temp_output = tempfile.mktemp(
                 dir=os.path.dirname(self.output))
         except EnvironmentError,e :
             logger.exception('while creating temp file for %r',
@@ -108,8 +108,6 @@ class Conversion(object):
         self.manager.conversion_finished(self)
 
     def _thread(self):
-        os.close(self.temp_fd)
-        os.unlink(self.temp_output) # unlink temp file before FFmpeg gets it
         try:
             commandline = self.get_subprocess_arguments(self.temp_output)
             self.popen = execute.Popen(commandline, bufsize=1)

--- a/mvc/video.py
+++ b/mvc/video.py
@@ -42,20 +42,15 @@ class VideoFile(object):
         key = (width, height, type_)
 
         if key not in self.thumbnails:
-            temp = tempfile.NamedTemporaryFile(
-                suffix=type_)
-            name = get_thumbnail(self.filename, width, height, temp.name,
+            temp_path = tempfile.mktemp(suffix=type_)
+            name = get_thumbnail(self.filename, width, height, temp_path,
                                  skip=skip)
             if name is None:
-                temp = None # no result
+                temp_path = None # no result
 
-            self.thumbnails[key] = temp
+            self.thumbnails[key] = temp_path
 
-        temp = self.thumbnails[key]
-        if temp is None:
-            return None
-        else:
-            return temp.name
+        return self.thumbnails.get(key)
 
 
 class Node(object):


### PR DESCRIPTION
Switched to using tempfile.mktemp() rather than NamedTemporaryFile() which
uses mkstemp().  Using mkstemp() doesn't work on windows because of file
locking issues.

It doesn't really make sense on unix either since we're passing the filename
to ffmpeg.  In that case, creating a file then deleting it from the MVC
process does nothing.

Changed conversion.py to use mktemp() as well.
