### PR TITLE
Fixed Ogg Theora encoding quality

### DIFF
--- a/mvc/basicconverters.py
+++ b/mvc/basicconverters.py
@@ -40,7 +40,7 @@ class OggVorbis(converter.FFmpegConverterInfo):
 class OggTheora(converter.FFmpegConverterInfo):
     media_type = 'format'
     extension = 'ogv'
-    parameters = '-f ogg -vcodec libtheora -acodec libvorbis -aq 60'
+    parameters = '-f ogg -codec:v libtheora -qscale:v 7 -codec:a libvorbis -qscale:a 5'
 
 class DNxHD_1080(converter.FFmpegConverterInfo1080p):
     media_type = 'format'


### PR DESCRIPTION
The current ffmpeg parameters for Ogg Theora leads to very low quality video. This changes uses the example command-line from http://trac.ffmpeg.org/wiki/TheoraVorbisEncodingGuide (which is within their "good range to try" suggestions).

This addresses the issue at http://pculture.freshdesk.com/support/discussions/topics/13550. (Not sure what the Bugzilla bug ID is, otherwise I'd include it here too.)
